### PR TITLE
Fix create appointment date constraint

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  resources :appointments
+  resources :appointments, only: [:create]
 
   get 'user/appointments', to: 'user_appointments#appointments'
 end

--- a/spec/controllers/appointments_controller_spec.rb
+++ b/spec/controllers/appointments_controller_spec.rb
@@ -7,9 +7,6 @@ RSpec.describe AppointmentsController, type: :controller do
   let(:time_date) { time_now.strftime("%Y-%m-%d") }
   let(:time_hour) { time_now.strftime("%H:00") }
   let(:user) { User.create!(email: email) }
-  let!(:appointment) do
-    Appointment.create!(email: email, time_slot: time_slot, user_id: user.id)
-  end
 
   describe 'POST /appointments' do
     let(:payload) { { email: email, date: time_date, time: time_hour } }
@@ -26,6 +23,30 @@ RSpec.describe AppointmentsController, type: :controller do
 
         expect(response.content_type).to eq('application/json')
         expect(response).to have_http_status(:created)
+      end
+
+      context 'when a user has another appointment for the same day' do
+        before do
+          Appointment.create!(email: email, time_slot: time_slot, user_id: user.id)
+        end
+
+        # Same date, just an hour ahead
+        let(:time_hour) { (time_now + 1.hour).strftime("%H:00") }
+
+        it 'renders a JSON response with a status code 200' do
+          subject
+
+          expect(response.content_type).to eq('application/json')
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'contains a message, but no new appointment' do
+          subject
+
+          api_response = "Error scheduling an appointment, time slot is unavailable"
+          json_response = JSON.parse(response.body)
+          expect(json_response["data"]["message"]).to eq(api_response)
+        end
       end
     end
   end


### PR DESCRIPTION
There was a bug with `date_parse/1` that did not parse the date properly.
This allowed appointments for the same date possible. This is now fixed.